### PR TITLE
Incorrectly identifying 5.8.9 as 5.8.0.

### DIFF
--- a/lib/Devel/PatchPerl.pm
+++ b/lib/Devel/PatchPerl.pm
@@ -214,7 +214,7 @@ sub _determine_version {
       my ($foo,$bar) = ( split /\s+/ )[1,2];
       $defines{$foo} = $bar;
     }
-    if ( my @wotsits = grep { defined $defines{$_} } qw(PERL_REVISION PERL_VERSION PERL_API_SUBVERSION) ) {
+    if ( my @wotsits = grep { defined $defines{$_} } qw(PERL_REVISION PERL_VERSION PERL_SUBVERSION) ) {
       $version = join '.', map { $defines{$_} } @wotsits;
     }
     else {

--- a/t/02_vers.t
+++ b/t/02_vers.t
@@ -4,8 +4,10 @@ use Test::More qq'no_plan';
 use File::Spec;
 use Devel::PatchPerl;
 my %vers = (
-  File::Spec->catdir( 't', 'modern' ), '5.15.1',
-  File::Spec->catdir( 't', 'old' ), '5.005_04',
+  File::Spec->catdir( 't', 'modern' )           => '5.15.1',
+  File::Spec->catdir( 't', 'old' )              => '5.005_04',
+  File::Spec->catdir( 't', 'perl-5.8.9' )       => '5.8.9',
+  File::Spec->catdir( 't', 'perl-5.10.1' )      => '5.10.1',
 );
 foreach my $dir ( keys %vers ) {
   my $vers = Devel::PatchPerl::_determine_version($dir);

--- a/t/perl-5.10.1/patchlevel.h
+++ b/t/perl-5.10.1/patchlevel.h
@@ -1,0 +1,147 @@
+/*    patchlevel.h
+ *
+ *    Copyright (C) 1993, 1995, 1996, 1997, 1998, 1999, 2000, 2001, 2002,
+ *    2003, 2004, 2005, 2006, 2007, 2008, 2009, by Larry Wall and others
+ *
+ *    You may distribute under the terms of either the GNU General Public
+ *    License or the Artistic License, as specified in the README file.
+ *
+ */
+
+#ifndef __PATCHLEVEL_H_INCLUDED__
+
+/* do not adjust the whitespace! Configure expects the numbers to be
+ * exactly on the third column */
+
+#define PERL_REVISION	5		/* age */
+#define PERL_VERSION	10		/* epoch */
+#define PERL_SUBVERSION	1		/* generation */
+
+/* The following numbers describe the earliest compatible version of
+   Perl ("compatibility" here being defined as sufficient binary/API
+   compatibility to run XS code built with the older version).
+   Normally this should not change across maintenance releases.
+
+   Note that this only refers to an out-of-the-box build.  Many non-default
+   options such as usemultiplicity tend to break binary compatibility
+   more often.
+
+   This is used by Configure et al to figure out 
+   PERL_INC_VERSION_LIST, which lists version libraries
+   to include in @INC.  See INSTALL for how this works.
+*/
+#define PERL_API_REVISION	5	/* Adjust manually as needed.  */
+#define PERL_API_VERSION	10	/* Adjust manually as needed.  */
+#define PERL_API_SUBVERSION	0	/* Adjust manually as needed.  */
+/*
+   XXX Note:  The selection of non-default Configure options, such
+   as -Duselonglong may invalidate these settings.  Currently, Configure
+   does not adequately test for this.   A.D.  Jan 13, 2000
+*/
+
+#define __PATCHLEVEL_H_INCLUDED__
+#endif
+
+/*
+	local_patches -- list of locally applied less-than-subversion patches.
+	If you're distributing such a patch, please give it a name and a
+	one-line description, placed just before the last NULL in the array
+	below.  If your patch fixes a bug in the perlbug database, please
+	mention the bugid.  If your patch *IS* dependent on a prior patch,
+	please place your applied patch line after its dependencies. This
+	will help tracking of patch dependencies.
+
+	Please either use 'diff --unified=0' if your diff supports
+	that or edit the hunk of the diff output which adds your patch
+	to this list, to remove context lines which would give patch
+	problems. For instance, if the original context diff is
+
+	   *** patchlevel.h.orig	<date here>
+	   --- patchlevel.h	<date here>
+	   *** 38,43 ***
+	   --- 38,44 ---
+	     	,"FOO1235 - some patch"
+	     	,"BAR3141 - another patch"
+	     	,"BAZ2718 - and another patch"
+	   + 	,"MINE001 - my new patch"
+	     	,NULL
+	     };
+	
+	please change it to 
+	   *** patchlevel.h.orig	<date here>
+	   --- patchlevel.h	<date here>
+	   *** 41,43 ***
+	   --- 41,44 ---
+	   + 	,"MINE001 - my new patch"
+	     	,NULL
+	     };
+	
+	(Note changes to line numbers as well as removal of context lines.)
+	This will prevent patch from choking if someone has previously
+	applied different patches than you.
+
+        History has shown that nobody distributes patches that also
+        modify patchlevel.h. Do it yourself. The following perl
+        program can be used to add a comment to patchlevel.h:
+
+#!perl
+die "Usage: perl -x patchlevel.h comment ..." unless @ARGV;
+open PLIN, "patchlevel.h" or die "Couldn't open patchlevel.h : $!";
+open PLOUT, ">patchlevel.new" or die "Couldn't write on patchlevel.new : $!";
+my $seen=0;
+while (<PLIN>) {
+    if (/\t,NULL/ and $seen) {
+       while (my $c = shift @ARGV){
+            print PLOUT qq{\t,"$c"\n};
+       }
+    }
+    $seen++ if /local_patches\[\]/;
+    print PLOUT;
+}
+close PLOUT or die "Couldn't close filehandle writing to patchlevel.new : $!";
+close PLIN or die "Couldn't close filehandle reading from patchlevel.h : $!";
+close DATA; # needed to allow unlink to work win32.
+unlink "patchlevel.bak" or warn "Couldn't unlink patchlevel.bak : $!"
+  if -e "patchlevel.bak";
+rename "patchlevel.h", "patchlevel.bak" or
+  die "Couldn't rename patchlevel.h to patchlevel.bak : $!";
+rename "patchlevel.new", "patchlevel.h" or
+  die "Couldn't rename patchlevel.new to patchlevel.h : $!";
+__END__
+
+Please keep empty lines below so that context diffs of this file do
+not ever collect the lines belonging to local_patches() into the same
+hunk.
+
+ */
+
+#if !defined(PERL_PATCHLEVEL_H_IMPLICIT) && !defined(LOCAL_PATCH_COUNT)
+#  if defined(PERL_IS_MINIPERL)
+#    define PERL_PATCHNUM "UNKNOWN-miniperl"
+#    define PERL_GIT_UNCOMMITTED_CHANGES ,"UNKNOWN"
+#    define PERL_GIT_UNPUSHED_COMMITS /*leave-this-comment*/
+#  elif defined(PERL_MICRO)
+#    define PERL_PATCHNUM "UNKNOWN-microperl"
+#    define PERL_GIT_UNCOMMITTED_CHANGES ,"UNKNOWN"
+#    define PERL_GIT_UNPUSHED_COMMITS /*leave-this-comment*/
+#  else
+#include "git_version.h"
+#  endif
+static const char * const local_patches[] = {
+	NULL
+	PERL_GIT_UNPUSHED_COMMITS    	/* do not remove this line */
+        PERL_GIT_UNCOMMITTED_CHANGES	/* do not remove this line */
+	,NULL
+};
+
+
+
+/* Initial space prevents this variable from being inserted in config.sh  */
+#  define	LOCAL_PATCH_COUNT	\
+	((int)(sizeof(local_patches)/sizeof(local_patches[0])-2))
+
+/* the old terms of reference, add them only when explicitly included */
+#define PATCHLEVEL		PERL_VERSION
+#undef  SUBVERSION		/* OS/390 has a SUBVERSION in a system header */
+#define SUBVERSION		PERL_SUBVERSION
+#endif

--- a/t/perl-5.8.9/patchlevel.h
+++ b/t/perl-5.8.9/patchlevel.h
@@ -1,0 +1,137 @@
+/*    patchlevel.h
+ *
+ *    Copyright (C) 1993, 1995, 1996, 1997, 1998, 1999, 2000, 2001,
+ *    2002, 2003, 2004, 2005, 2006, 2007, by Larry Wall and others
+ *
+ *    You may distribute under the terms of either the GNU General Public
+ *    License or the Artistic License, as specified in the README file.
+ *
+ */
+
+#ifndef __PATCHLEVEL_H_INCLUDED__
+
+/* do not adjust the whitespace! Configure expects the numbers to be
+ * exactly on the third column */
+
+#define PERL_REVISION	5		/* age */
+#define PERL_VERSION	8		/* epoch */
+#define PERL_SUBVERSION	9		/* generation */
+
+/* The following numbers describe the earliest compatible version of
+   Perl ("compatibility" here being defined as sufficient binary/API
+   compatibility to run XS code built with the older version).
+   Normally this should not change across maintenance releases.
+
+   Note that this only refers to an out-of-the-box build.  Many non-default
+   options such as usemultiplicity tend to break binary compatibility
+   more often.
+
+   This is used by Configure et al to figure out 
+   PERL_INC_VERSION_LIST, which lists version libraries
+   to include in @INC.  See INSTALL for how this works.
+*/
+#define PERL_API_REVISION	5	/* Adjust manually as needed.  */
+#define PERL_API_VERSION	8	/* Adjust manually as needed.  */
+#define PERL_API_SUBVERSION	0	/* Adjust manually as needed.  */
+/*
+   XXX Note:  The selection of non-default Configure options, such
+   as -Duselonglong may invalidate these settings.  Currently, Configure
+   does not adequately test for this.   A.D.  Jan 13, 2000
+*/
+
+#define __PATCHLEVEL_H_INCLUDED__
+#endif
+
+/*
+	local_patches -- list of locally applied less-than-subversion patches.
+	If you're distributing such a patch, please give it a name and a
+	one-line description, placed just before the last NULL in the array
+	below.  If your patch fixes a bug in the perlbug database, please
+	mention the bugid.  If your patch *IS* dependent on a prior patch,
+	please place your applied patch line after its dependencies. This
+	will help tracking of patch dependencies.
+
+	Please either use 'diff --unified=0' if your diff supports
+	that or edit the hunk of the diff output which adds your patch
+	to this list, to remove context lines which would give patch
+	problems. For instance, if the original context diff is
+
+	   *** patchlevel.h.orig	<date here>
+	   --- patchlevel.h	<date here>
+	   *** 38,43 ***
+	   --- 38,44 ---
+	     	,"FOO1235 - some patch"
+	     	,"BAR3141 - another patch"
+	     	,"BAZ2718 - and another patch"
+	   + 	,"MINE001 - my new patch"
+	     	,NULL
+	     };
+	
+	please change it to 
+	   *** patchlevel.h.orig	<date here>
+	   --- patchlevel.h	<date here>
+	   *** 41,43 ***
+	   --- 41,44 ---
+	   + 	,"MINE001 - my new patch"
+	     	,NULL
+	     };
+	
+	(Note changes to line numbers as well as removal of context lines.)
+	This will prevent patch from choking if someone has previously
+	applied different patches than you.
+
+        History has shown that nobody distributes patches that also
+        modify patchlevel.h. Do it yourself. The following perl
+        program can be used to add a comment to patchlevel.h:
+
+#!perl
+die "Usage: perl -x patchlevel.h comment ..." unless @ARGV;
+open PLIN, "patchlevel.h" or die "Couldn't open patchlevel.h : $!";
+open PLOUT, ">patchlevel.new" or die "Couldn't write on patchlevel.new : $!";
+my $seen=0;
+while (<PLIN>) {
+    if (/\t,NULL/ and $seen) {
+       while (my $c = shift @ARGV){
+            print PLOUT qq{\t,"$c"\n};
+       }
+    }
+    $seen++ if /local_patches\[\]/;
+    print PLOUT;
+}
+close PLOUT or die "Couldn't close filehandle writing to patchlevel.new : $!";
+close PLIN or die "Couldn't close filehandle reading from patchlevel.h : $!";
+close DATA; # needed to allow unlink to work win32.
+unlink "patchlevel.bak" or warn "Couldn't unlink patchlevel.bak : $!"
+  if -e "patchlevel.bak";
+rename "patchlevel.h", "patchlevel.bak" or
+  die "Couldn't rename patchlevel.h to patchlevel.bak : $!";
+rename "patchlevel.new", "patchlevel.h" or
+  die "Couldn't rename patchlevel.new to patchlevel.h : $!";
+__END__
+
+Please keep empty lines below so that context diffs of this file do
+not ever collect the lines belonging to local_patches() into the same
+hunk.
+
+ */
+
+
+
+
+#if !defined(PERL_PATCHLEVEL_H_IMPLICIT) && !defined(LOCAL_PATCH_COUNT)
+static const char *local_patches[] = {
+	NULL
+	,NULL
+};
+
+
+
+/* Initial space prevents this variable from being inserted in config.sh  */
+#  define	LOCAL_PATCH_COUNT	\
+	((int)(sizeof(local_patches)/sizeof(local_patches[0])-2))
+
+/* the old terms of reference, add them only when explicitly included */
+#define PATCHLEVEL		PERL_VERSION
+#undef  SUBVERSION		/* OS/390 has a SUBVERSION in a system header */
+#define SUBVERSION		PERL_SUBVERSION
+#endif


### PR DESCRIPTION
Need to look at `PERL_SUBVERSION` not `PERL_API_SUBVERSION`.  `PERL_API_*` is for the API version,
not Perl itself.  For 5.8.9 it is 0.  Also verified using 5.10.1.

This was resulting in the misapplying of a patch to DB_File.
