### PR TITLE
update deprecated GitHub Actions commands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: setup perl
         run: |
           echo "$HOME/perl5/bin" >> "$GITHUB_PATH"
-          echo "PERL5LIB::$HOME/perl5/lib/perl5" >> "$GITHUB_ENV"
+          echo "PERL5LIB=$HOME/perl5/lib/perl5" >> "$GITHUB_ENV"
       - name: install dependencies
         run: |
           curl -L https://cpanmin.us | perl - -L ~/perl5 App::cpanminus
@@ -238,7 +238,7 @@ jobs:
       - name: setup perl
         run: |
           echo "$HOME/perl5/bin" >> "$GITHUB_PATH"
-          echo "PERL5LIB::$HOME/perl5/lib/perl5" >> "$GITHUB_ENV"
+          echo "PERL5LIB=$HOME/perl5/lib/perl5" >> "$GITHUB_ENV"
       - uses: actions/download-artifact@v2
         with:
           name: Devel-PatchPerl.tar.gz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,8 @@ jobs:
 
       - name: setup perl
         run: |
-          echo "::add-path::$HOME/perl5/bin"
-          echo "::set-env name=PERL5LIB::$HOME/perl5/lib/perl5"
+          echo "$HOME/perl5/bin" >> "$GITHUB_PATH"
+          echo "PERL5LIB::$HOME/perl5/lib/perl5" >> "$GITHUB_ENV"
       - name: install dependencies
         run: |
           curl -L https://cpanmin.us | perl - -L ~/perl5 App::cpanminus
@@ -237,8 +237,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: setup perl
         run: |
-          echo "::add-path::$HOME/perl5/bin"
-          echo "::set-env name=PERL5LIB::$HOME/perl5/lib/perl5"
+          echo "$HOME/perl5/bin" >> "$GITHUB_PATH"
+          echo "PERL5LIB::$HOME/perl5/lib/perl5" >> "$GITHUB_ENV"
       - uses: actions/download-artifact@v2
         with:
           name: Devel-PatchPerl.tar.gz


### PR DESCRIPTION
add-path and set-env are deprecated for security reason.
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
update them to use the new environment files.
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files