### PR TITLE
bump GitHub Actions to latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: perl -V
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Cache multiple paths
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/perl5
@@ -34,7 +34,7 @@ jobs:
       - run: dzil test
       - run: dzil build
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: Devel-PatchPerl.tar.gz
           path: Devel-PatchPerl-*.tar.gz
@@ -234,12 +234,12 @@ jobs:
           - "5.8.0"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: setup perl
         run: |
           echo "$HOME/perl5/bin" >> "$GITHUB_PATH"
           echo "PERL5LIB=$HOME/perl5/lib/perl5" >> "$GITHUB_ENV"
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: Devel-PatchPerl.tar.gz
       - name: install dependencies


### PR DESCRIPTION
fix the following warning:

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/cache@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

https://github.com/bingos/devel-patchperl/actions/runs/7012246590